### PR TITLE
[feat] Player 움직임 구현

### DIFF
--- a/Assets/Scenes/TestScene.unity
+++ b/Assets/Scenes/TestScene.unity
@@ -211,8 +211,227 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &690842582
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 690842583}
+  - component: {fileID: 690842584}
+  m_Layer: 0
+  m_Name: PlayerManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &690842583
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 690842582}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1275.0149, y: 426.07092, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &690842584
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 690842582}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 715bec8f51aa7054b91a046abb005140, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::PlayerManager
+  inputHandler: {fileID: 1036447606}
+  playerBehavior: {fileID: 1036447605}
+--- !u!1 &1036447599
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1036447603}
+  - component: {fileID: 1036447602}
+  - component: {fileID: 1036447601}
+  - component: {fileID: 1036447600}
+  - component: {fileID: 1036447606}
+  - component: {fileID: 1036447605}
+  - component: {fileID: 1036447604}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!135 &1036447600
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1036447599}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Radius: 0.5
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1036447601
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1036447599}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9452ae1262a74094f8a68013fbcd1834, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_MaskInteraction: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1036447602
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1036447599}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1036447603
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1036447599}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1275.0149, y: 426.07092, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1036447604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1036447599}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.InputSystem::UnityEngine.InputSystem.PlayerInput
+  m_Actions: {fileID: -944628639613478452, guid: 2bcd2660ca9b64942af0de543d8d7100, type: 3}
+  m_NotificationBehavior: 0
+  m_UIInputModule: {fileID: 0}
+  m_DeviceLostEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_DeviceRegainedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ControlsChangedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ActionEvents: []
+  m_NeverAutoSwitchControlSchemes: 0
+  m_DefaultControlScheme: 
+  m_DefaultActionMap: Player
+  m_SplitScreenIndex: -1
+  m_Camera: {fileID: 0}
+--- !u!114 &1036447605
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1036447599}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc1a1c89eae60444c9d8fa6dadef4dcc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::PlayerBehavior
+  smoothing: 15
+--- !u!114 &1036447606
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1036447599}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1fb3def7c60cfe243814238ec0aad542, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::PlayerInputHandler
+  inputThreshold: 0.5
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 195504708}
+  - {fileID: 690842583}
+  - {fileID: 1036447603}

--- a/Assets/Scripts/Player/PlayerBehavior.cs
+++ b/Assets/Scripts/Player/PlayerBehavior.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+public class PlayerBehavior : MonoBehaviour
+{
+    [SerializeField] private float smoothing = 15f;
+    private PlayerDomain _domain;
+    private Vector3 _displayPos;
+
+    public void Initialize(PlayerDomain domain)
+    {
+        _domain = domain;
+        _displayPos = transform.position;
+    }
+
+    void Update()
+    {
+        if (_domain == null) return;
+        Vector3 targetPos = new Vector3(_domain.Position.x, _domain.Position.y, 0);
+        _displayPos = Vector3.Lerp(_displayPos, targetPos, smoothing * Time.deltaTime);
+        transform.position = _displayPos;
+    }
+}

--- a/Assets/Scripts/Player/PlayerBehavior.cs.meta
+++ b/Assets/Scripts/Player/PlayerBehavior.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bc1a1c89eae60444c9d8fa6dadef4dcc

--- a/Assets/Scripts/Player/PlayerDomain.cs
+++ b/Assets/Scripts/Player/PlayerDomain.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+public class PlayerDomain
+{
+    public Vector2 Position { get; set; }
+    public Vector2 Direction { get; set; }
+    public float Speed { get; } = 5f;
+
+    // 서버 보정을 위한 입력 기록 (Reconciliation용)
+    public struct InputFrame { public Vector2 dir; public float dt; }
+    public Queue<InputFrame> InputHistory = new Queue<InputFrame>();
+
+    public PlayerDomain() => Position = Vector2.zero;
+}

--- a/Assets/Scripts/Player/PlayerDomain.cs.meta
+++ b/Assets/Scripts/Player/PlayerDomain.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f8dd773a53bb2fb4096a61e9ed79e683

--- a/Assets/Scripts/Player/PlayerInputHandler.cs
+++ b/Assets/Scripts/Player/PlayerInputHandler.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+using System.Collections;
+
+public class PlayerInputHandler : MonoBehaviour
+{
+    [SerializeField] private float inputThreshold = 0.5f; // 조이스틱 입력 민감도
+    private PlayerInput playerInput;
+    private InputAction moveAction;
+    private PlayerMoveService _moveService;
+
+    void Awake()
+    {
+        playerInput = GetComponent<PlayerInput>();
+        moveAction = playerInput.actions["Move"];
+    }
+
+    void Update()
+    {
+        
+    }
+    void OnEnable()
+    {
+        // "Move" 액션이 수행될 때(눌리거나 움직일 때)만 OnMoveContext 함수 실행
+        moveAction.performed += OnMoveContext;
+        // 키를 뗐을 때 실행
+        moveAction.canceled += OnMoveContext;
+    }
+
+    public void Initialize(PlayerMoveService _moveService)
+    {
+        this._moveService = _moveService;
+    }
+    // 시스템이 호출해주는 콜백 함수
+
+    private void OnMoveContext(InputAction.CallbackContext context)
+    {
+        Vector2 input = context.ReadValue<Vector2>();
+        if (input != Vector2.zero) Debug.Log($"Input Detected: {input}");
+        //if (input == Vector2.zero) return; // 입력 값 없으면 무시
+
+        // 입력을 정수 그리드 방향으로 변환 (joystick threshold 이상 움직였을 경우)
+        float x = 0;
+        float y = 0;
+        if (Mathf.Abs(input.x) > inputThreshold) x = Mathf.Sign(input.x);
+        if (Mathf.Abs(input.y) > inputThreshold) y = Mathf.Sign(input.y);
+
+        Vector3 direction = new Vector3(x, y, 0);
+
+        // Application 레이어 호출 (사용자 입력 방향을 전달)
+        _moveService.SetDirection(direction);
+    }
+}

--- a/Assets/Scripts/Player/PlayerInputHandler.cs.meta
+++ b/Assets/Scripts/Player/PlayerInputHandler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1fb3def7c60cfe243814238ec0aad542

--- a/Assets/Scripts/Player/PlayerManager.cs
+++ b/Assets/Scripts/Player/PlayerManager.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+using UnityEngine.InputSystem; // 1. 반드시 추가해야 함
+
+public class PlayerManager : MonoBehaviour
+{
+    [SerializeField] private PlayerInputHandler inputHandler;
+    [SerializeField] private PlayerBehavior playerBehavior;
+
+    private PlayerDomain _domain;
+    private PlayerMoveService _moveService;
+
+    void Awake()
+    {
+        // 객체 생성 및 의존성 주입
+        _domain = new PlayerDomain();
+        _moveService = new PlayerMoveService(_domain);
+
+        // 각 컴포넌트 초기화
+        inputHandler.Initialize(_moveService);
+        playerBehavior.Initialize(_domain);
+    }
+
+    void Update()
+    {
+        // 매 프레임 클라이언트 예측 이동을 실행
+        _moveService.Tick(Time.deltaTime);
+        // 테스트 코드
+        if (Keyboard.current != null)
+        {
+            //플레이어 위치를 threshold 이상 이동시켜서 reconcile이 일어나는 것을 체크 (space바로 체크)
+            if (Keyboard.current.spaceKey.wasPressedThisFrame)
+            {
+                TestReconcile();
+            }
+
+            // 네트워크 지연 상황을 임의로 구현(100ms 이전의 위치가 서버에서 전송한 플레이어의 위치일 때)
+            if (Keyboard.current.tKey.wasPressedThisFrame)
+            {
+                Debug.Log("100ms 지연 후 보정 시뮬레이션 시작...");
+                StartCoroutine(FakeNetworkDelay());
+            }
+        }
+    }
+
+    private void TestReconcile()
+    {
+        Debug.Log("--- 서버 보정(Reconcile) 테스트 ---");
+        Vector2 currentPos = _domain.Position;
+        
+        // 현재 위치에서 뒤로 2m 지점을 서버 위치로 가제트
+        Vector2 fakeServerPos = currentPos - (_domain.Direction * 2.0f); 
+        _moveService.Reconcile(fakeServerPos);
+        
+        Debug.Log($"보정 전: {currentPos} -> 보정 후: {_domain.Position}");
+    }
+
+    private System.Collections.IEnumerator FakeNetworkDelay()
+    {
+        Vector2 serverPoint = _domain.Position;
+        yield return new WaitForSeconds(0.1f); // 100ms 지연
+        _moveService.Reconcile(serverPoint);
+        Debug.Log("지연 보정 완료!");
+    }
+
+    public void OnServerPositionReceived(Vector2 pos) => _moveService.Reconcile(pos);
+}

--- a/Assets/Scripts/Player/PlayerManager.cs.meta
+++ b/Assets/Scripts/Player/PlayerManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 715bec8f51aa7054b91a046abb005140

--- a/Assets/Scripts/Player/PlayerMoveService.cs
+++ b/Assets/Scripts/Player/PlayerMoveService.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+public class PlayerMoveService
+{
+    private readonly PlayerDomain _domain;
+    //reconciliation을 수행할 최소 오차
+    private readonly float _reconcileThreshold = 0.05f;
+    private readonly int _maxHistoryCount = 100;
+
+    public PlayerMoveService(PlayerDomain domain) => _domain = domain;
+
+    public void SetDirection(Vector2 dir) => _domain.Direction = dir.normalized;
+
+    public void Tick(float deltaTime)
+    {
+        if (_domain.Direction == Vector2.zero) return;
+
+        Vector2 movement = _domain.Direction * _domain.Speed * deltaTime;
+        _domain.Position += movement;
+
+        // Reconciliation을 수행할 떄 사용할 사용자 인풋 로그
+        _domain.InputHistory.Enqueue(new PlayerDomain.InputFrame { dir = _domain.Direction, dt = deltaTime });
+        if (_domain.InputHistory.Count > _maxHistoryCount) _domain.InputHistory.Dequeue();
+    }
+
+    // 서버 패킷 수신 시 호출되는 보정 로직
+    public void Reconcile(Vector2 serverPos)
+    {
+        // 서버 결과와 현재 위치의 차이가 Threshold보다 작으면 무시
+        if (Vector2.Distance(_domain.Position, serverPos) < _reconcileThreshold) return;
+
+        // History에 저장된 인풋을 적용하여 현재 위치 다시 측정
+        _domain.Position = serverPos;
+        foreach (var frame in _domain.InputHistory)
+        {
+            _domain.Position += frame.dir * _domain.Speed * frame.dt;
+        }
+    }
+}

--- a/Assets/Scripts/Player/PlayerMoveService.cs.meta
+++ b/Assets/Scripts/Player/PlayerMoveService.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 910b08b81c11461478973131d11d752a


### PR DESCRIPTION
## 개요

이번 PR에서 작업한 내용을 요약해 주세요.

## 관련 이슈
플레이어 움직임 구현

- #이슈번호
14
## 작업 내용
 1. player의 상태 정보를 나타낼 Domain 생성 및 정의
- player 정보: position, direction, Input History

 2. Player로부터 입력을 받을 인터페이스 정의(PlayerInputHandler)

 3. Player의 입력과 도메인, 매니저, 인프라 등을 중계할 application을 정의 (PlayerMoveService)

함수 목록
 - SetDirection(Vector2 dir)
   - Domain에 입력을 전달
 - Tick(float deltaTime)
   - client의 현재 예측 위치 및 history를 domain에 전달
- Reconcile(Vector2 serverPos)
  - 서버의 위치에 맞춰 보정

 4. Player Manager에서 매 프레임 Tick 실행

 5. PlayerBehavior에서 매 프레임 현재 플레이어 현재 위치 화면에 렌더

### 테스트 방법
space bar: 현재 이동 방향에서 뒤로 2만큼 이동
t: network 전송 지연 100ms (실제 네트워크 100ms 지연시키는 방식은 아님)

## 테스트 결과

약 100초의 전송 지연의 경우 약간 튀는 느낌 있음, 

## 기타

없음
