### PR TITLE
[Feat]: Unity Editor 상 Dev 로그인 구현

### DIFF
--- a/Assets/Scripts/Network/DTOs/User/UserResponse.cs
+++ b/Assets/Scripts/Network/DTOs/User/UserResponse.cs
@@ -33,4 +33,14 @@ namespace Metamong.Core
     /// <summary>RC가 아직 배정되지 않은 상태</summary>
     public bool IsRcUnassigned => Rc == RC.UNASSIGNED;
   }
+
+  /// <summary>POST /api/auth/dev-login 응답 스키마 (에디터 전용)</summary>
+  public class TokenResponse
+  {
+    [JsonProperty("access_token")] public string AccessToken { get; set; }
+    [JsonProperty("token_type")]   public string TokenType   { get; set; }
+    [JsonProperty("user_id")]      public int    UserId      { get; set; }
+    [JsonProperty("email")]        public string Email       { get; set; }
+    [JsonProperty("nickname")]     public string Nickname    { get; set; }
+  }
 }

--- a/Assets/Scripts/Network/FastAPIHandler.cs
+++ b/Assets/Scripts/Network/FastAPIHandler.cs
@@ -25,6 +25,7 @@ public class FastAPIHandler
     private const string EP_ME = "/api/users/me";
     private const string EP_ME_RC = "/api/users/me/rc";
     private const string EP_ME_INIT = "/api/users/me/initialize";
+    private const string EP_DEV_LOGIN = "/api/auth/dev-login";
     // Newtonsoft 직렬화 설정 (snake_case → C# 프로퍼티)
     private static readonly JsonSerializerSettings _jsonSettings = new JsonSerializerSettings
     {
@@ -50,6 +51,9 @@ public class FastAPIHandler
         BACKEND_URL = FastAPIUrl;
 #if UNITY_WEBGL && !UNITY_EDITOR
         NotifyUnityReady();
+#endif
+#if UNITY_EDITOR
+        _runner.StartCoroutine(DevLogin());
 #endif
     }
 
@@ -293,4 +297,41 @@ public class FastAPIHandler
         AccessToken = null;
         CurrentUser = null;
     }
+
+#if UNITY_EDITOR
+    // 에디터 전용: dev-login 엔드포인트로 토큰 자동 발급
+    private IEnumerator DevLogin()
+    {
+        Debug.Log("[Auth][Editor] dev-login 시도");
+        using (UnityWebRequest www = new UnityWebRequest($"{BACKEND_URL}{EP_DEV_LOGIN}", "POST"))
+        {
+            www.uploadHandler   = new UploadHandlerRaw(new byte[0]);
+            www.downloadHandler = new DownloadHandlerBuffer();
+            www.SetRequestHeader("Content-Type", "application/json");
+            yield return www.SendWebRequest();
+
+            if (www.result == UnityWebRequest.Result.Success)
+            {
+                try
+                {
+                    var resp = JsonConvert.DeserializeObject<Metamong.Core.TokenResponse>(
+                        www.downloadHandler.text, _jsonSettings);
+                    if (resp != null && !string.IsNullOrEmpty(resp.AccessToken))
+                    {
+                        Debug.Log($"[Auth][Editor] dev-login 성공 | user: {resp.Nickname}");
+                        ReceiveToken(resp.AccessToken);
+                    }
+                }
+                catch (JsonException e)
+                {
+                    Debug.LogError($"[Auth][Editor] TokenResponse 역직렬화 실패: {e.Message}");
+                }
+            }
+            else
+            {
+                Debug.LogWarning($"[Auth][Editor] dev-login 실패: {www.responseCode} {www.error}");
+            }
+        }
+    }
+#endif
 }

--- a/Assets/Scripts/Network/NetworkCore.cs
+++ b/Assets/Scripts/Network/NetworkCore.cs
@@ -33,7 +33,12 @@ public class NetworkCore : INetworkProvider
     //수정해야함, 범용성이 너무 낮지만 일단 씀,,
     public async Task JoinSquare()
     {
-        await _colyseusHandler.JoinRoom<MyRoomState>(_settings.gameRoomName, _settings.jwt);
+        if (_fastAPIHandler == null || !_fastAPIHandler.IsLoggedIn)
+        {
+            Debug.LogWarning("[NetworkCore] JoinSquare 실패: 로그인 상태가 아닙니다.");
+            return;
+        }
+        await _colyseusHandler.JoinRoom<MyRoomState>(_settings.gameRoomName, _fastAPIHandler.AccessToken);
     }
 
     public void SubscribeLocalData(Action<Vector2> e) => _colyseusHandler.onPositionReceived += e;


### PR DESCRIPTION
## 개요

유니티 에디터에서 실행 시 NetworkRunner가 FastAPI 액세스 토큰을 dev-login 엔드포인트를 통해 가져오도록 설정

## 관련 이슈

없음.

## 작업 내용

- [x] dev-login response dto 작성
- [x] DevLogin 함수를 통해 `/api/auth/dev-login` 으로 post 요청
- [x] Colyseus `JoinSquare()`에서 `JoinRoom()` 할 때 파라미터로 token값을 ScriptableObject 값이 아닌 dev-login으로 받아온 토큰을 사용하도록 설정

## 테스트 결과

dev-login으로 유니티 에디터 상에서 자동 로그인 성공

